### PR TITLE
[CSL-2441] Apply a placeholder filter to enable backfilling

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -76,7 +76,7 @@ export const fetchBrowseReults = async (filterName, filterValue) => {
 };
 
 export const fetchRecommendations = async (podId) => {
-  const response = await cioClient.recommendations.getRecommendations(podId, { numResults: 6 });
+  const response = await cioClient.recommendations.getRecommendations(podId, { numResults: 6, filters: { group_id: 'AP01' } });
 
   return response;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -76,6 +76,7 @@ export const fetchBrowseReults = async (filterName, filterValue) => {
 };
 
 export const fetchRecommendations = async (podId) => {
+  // To avoid zero results, we apply a filter to enable backfilling via "filtered_items" strategy
   const response = await cioClient.recommendations.getRecommendations(podId, { numResults: 6, filters: { group_id: 'AP01' } });
 
   return response;


### PR DESCRIPTION
Enables recommendations backfilling via `filtered_items` strategy. More details in Linear.