### PR TITLE
Add .npmrc with security hardening settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+save-exact=true
+


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `ignore-scripts=true` and `save-exact=true`
- `ignore-scripts=true` prevents arbitrary code execution during `npm install` (supply chain defense)
- `save-exact=true` pins exact dependency versions for reproducible builds

## If a package requires install scripts

Add a per-package override in `.npmrc`:
```
; Allow install scripts for specific packages
ignore-scripts[@scope/package-name]=false
```

Or run one-off with:
```bash
npm install --ignore-scripts=false <package-name>
```

## Context
Part of an org-wide security hardening initiative for all npm-based repositories.